### PR TITLE
Block polygons

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -21,7 +21,7 @@
     </style>
   </head>
   <body>
-    <script src="main.js"></script>
+    <script src="/main.js"></script>
     <script type="text/javascript">Elm.Main.fullscreen()</script>
   </body>
 </html>

--- a/src/Turnabout/Block.elm
+++ b/src/Turnabout/Block.elm
@@ -11,7 +11,8 @@ import Svg.Attributes as Attributes
 import Svg.Lazy exposing (lazy2)
 import Color
 import Color.Convert exposing (colorToHex)
-import Turnabout.Coordinate exposing (Coordinate)
+import Turnabout.Coordinate as Coordinate exposing (Coordinate)
+import Turnabout.Direction exposing (Direction(..))
 
 
 type Block
@@ -48,25 +49,49 @@ viewShape size block =
         []
 
 
+type Cursor
+    = Cursor Direction Coordinate
+
+
+{-| This one is a doozy. This function will return a string of points for an Svg
+polygon element. To do so, we get a bit turtle-graphics-y and walk the
+perimeter, obeying a right-hand rule. It walks one unit at a time, incrementing
+the distance by the size parameter. When it reaches "home" (the top-left block,
+we return the beginning position. This means the algorithm builds the svg points
+in reverse.)
+-}
 perimeterPoints : Int -> Block -> String
-perimeterPoints size block =
-    perimeterPointsHelp size block [ ( 1, 1 ) ]
-        |> List.map (\( x, y ) -> (toString x) ++ "," ++ (toString y))
-        |> String.join " "
+perimeterPoints size (Block parts) =
+    let
+        blockToThe : Direction -> Coordinate -> Bool
+        blockToThe direction currentLocation =
+            List.member
+                (Coordinate.byOne direction currentLocation)
+                (( 0, 0 ) :: parts)
 
+        walkPerimeter : Cursor -> List Coordinate
+        walkPerimeter cursor =
+            case cursor of
+                Cursor West ( 1, 0 ) ->
+                    List.singleton ( 1, 1 )
 
-perimeterPointsHelp : Int -> Block -> List Coordinate -> List Coordinate
-perimeterPointsHelp size (Block parts) points =
-    case parts of
-        [] ->
-            [ ( 1, 1 )
-            , ( size - 1, 1 )
-            , ( size - 1, size - 1 )
-            , ( 1, size - 1 )
-            ]
+                Cursor North ( 0, 1 ) ->
+                    List.singleton ( 1, 1 )
 
-        head :: rest ->
-            perimeterPointsHelp size (Block rest) points
+                Cursor South ( x, y ) ->
+                    if blockToThe East ( x, y ) then
+                        ( x * size + 1, y * size + 1 ) :: walkPerimeter (Cursor East ( x + 1, y ))
+                    else if blockToThe West ( x, y ) then
+                        ( x * size + 1, y * size + 1 ) :: walkPerimeter (Cursor West ( x - 1, y ))
+                    else
+                        walkPerimeter (Cursor South ( x, y + size + 1 ))
+
+                Cursor _ _ ->
+                    Debug.crash "Not taking into account all cases"
+    in
+        walkPerimeter (Cursor South ( 1, 1 ))
+            |> List.map (\( x, y ) -> (toString x) ++ "," ++ (toString y))
+            |> String.join " "
 
 
 translateString : number -> number -> String

--- a/src/Turnabout/Coordinate.elm
+++ b/src/Turnabout/Coordinate.elm
@@ -1,6 +1,6 @@
 module Turnabout.Coordinate exposing (Coordinate, add, subtract, byOne)
 
-import Turnabout.Direction exposing (Direction(..))
+import Turnabout.Direction as Direction exposing (Cardinal(..))
 
 
 type alias Coordinate =
@@ -13,7 +13,7 @@ type alias Distance =
 
 {-| The coordinate, moved one unit in the given direction
 -}
-by : Distance -> Direction -> Coordinate -> Coordinate
+by : Distance -> Direction.Cardinal -> Coordinate -> Coordinate
 by distance direction ( x, y ) =
     case direction of
         South ->
@@ -31,7 +31,7 @@ by distance direction ( x, y ) =
 
 {-| The coordinate, moved one unit in the given direction
 -}
-byOne : Direction -> Coordinate -> Coordinate
+byOne : Direction.Cardinal -> Coordinate -> Coordinate
 byOne =
     by 1
 

--- a/src/Turnabout/Direction.elm
+++ b/src/Turnabout/Direction.elm
@@ -1,8 +1,15 @@
-module Turnabout.Direction exposing (Direction(..))
+module Turnabout.Direction exposing (Cardinal(..), Ordinal(..))
 
 
-type Direction
+type Cardinal
     = North
     | South
     | East
     | West
+
+
+type Ordinal
+    = NorthWest
+    | NorthEast
+    | SouthEast
+    | SouthWest

--- a/src/Turnabout/Level/Model.elm
+++ b/src/Turnabout/Level/Model.elm
@@ -15,7 +15,7 @@ module Turnabout.Level.Model
 
 import Dict exposing (Dict)
 import Set exposing (Set)
-import Turnabout.Direction exposing (Direction(..))
+import Turnabout.Direction as Direction exposing (Cardinal(..))
 import Turnabout.Coordinate as Coordinate exposing (Coordinate)
 import Turnabout.Marble exposing (Marble)
 import Turnabout.Moves exposing (Rotation(Clockwise, CounterClockwise), Moves)
@@ -156,7 +156,7 @@ applyMoves moves level =
     applyMovesHelp moves level South
 
 
-applyMovesHelp : Moves -> Level -> Direction -> Level
+applyMovesHelp : Moves -> Level -> Direction.Cardinal -> Level
 applyMovesHelp moves level gravity =
     case moves of
         [] ->
@@ -170,12 +170,12 @@ applyMovesHelp moves level gravity =
                 applyMovesHelp rest (shiftMovables g level) g
 
 
-shiftMovables : Direction -> Level -> Level
+shiftMovables : Direction.Cardinal -> Level -> Level
 shiftMovables direction level =
     { level | movables = List.map (moveUntilBlocked direction level) level.movables }
 
 
-moveUntilBlocked : Direction -> Level -> Movable -> Movable
+moveUntilBlocked : Direction.Cardinal -> Level -> Movable -> Movable
 moveUntilBlocked direction level movable =
     if isBlocked direction level movable then
         movable
@@ -197,7 +197,7 @@ moveUntilBlocked direction level movable =
 {-| Given a level and a movable, check to see if that movable has settled into
 a position where it can move no longer.
 -}
-isBlocked : Direction -> Level -> Movable -> Bool
+isBlocked : Direction.Cardinal -> Level -> Movable -> Bool
 isBlocked direction level movable =
     case movable of
         Murble _ coordinate ->
@@ -230,7 +230,7 @@ occupying candidate movable =
             List.any (flip (==) candidate) coordinates
 
 
-nextGravity : Rotation -> Direction -> Direction
+nextGravity : Rotation -> Direction.Cardinal -> Direction.Cardinal
 nextGravity rotation gravityDirection =
     case gravityDirection of
         South ->

--- a/src/Turnabout/Moves.elm
+++ b/src/Turnabout/Moves.elm
@@ -11,7 +11,7 @@ module Turnabout.Moves
         , toDirection
         )
 
-import Turnabout.Direction exposing (Direction(..))
+import Turnabout.Direction as Direction exposing (Cardinal(..))
 
 
 type Rotation
@@ -63,7 +63,7 @@ rotationInDegrees rotation =
             -90
 
 
-toDirection : Moves -> Direction
+toDirection : Moves -> Direction.Cardinal
 toDirection moves =
     case toDegrees moves % 360 of
         (-90) ->

--- a/tests/Turnabout/BlockTest.elm
+++ b/tests/Turnabout/BlockTest.elm
@@ -20,6 +20,16 @@ suite =
                 Block.singleton
                     |> Block.withPart ( 0, 1 )
                     |> expectPolygonWithPoints "1,1 19,1 19,39 1,39"
+        , test "draws some nutty concave thing" <|
+            \_ ->
+                Block.singleton
+                    |> Block.withPart ( 1, 0 )
+                    |> Block.withPart ( 1, 1 )
+                    |> Block.withPart ( 1, 2 )
+                    |> Block.withPart ( 1, 3 )
+                    |> Block.withPart ( 0, 3 )
+                    |> Block.withPart ( -1, 3 )
+                    |> expectPolygonWithPoints "1,1 39,1 39,79 -19,79 -19,61 21,61 21,19 1,19"
         ]
 
 

--- a/tests/Turnabout/BlockTest.elm
+++ b/tests/Turnabout/BlockTest.elm
@@ -2,25 +2,30 @@ module Turnabout.BlockTest exposing (suite)
 
 import Test exposing (..)
 import Expect
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (tag, attribute)
+import Svg.Attributes
 import Turnabout.Block as Block exposing (Block)
 
 
 suite : Test
 suite =
     describe "A block movable"
-        [ test "takes up at least one tile" <|
+        [ test "draws a square when given a one-unit block" <|
             \_ ->
                 Block.singleton
-                    |> (\block ->
-                            ( Block.width block, Block.height block )
-                       )
-                    |> Expect.equal ( 1, 1 )
-        , test "can be made of more than one tile" <|
+                    |> expectPolygonWithPoints "1,1 19,1 19,19 1,19"
+        , test "draws a 1x2 rectangle when given a block of that shape" <|
             \_ ->
                 Block.singleton
-                    |> Block.withPart ( 1, 0 )
-                    |> (\block ->
-                            ( Block.width block, Block.height block )
-                       )
-                    |> Expect.equal ( 2, 1 )
+                    |> Block.withPart ( 0, 1 )
+                    |> expectPolygonWithPoints "1,1 19,1 19,39 1,39"
         ]
+
+
+expectPolygonWithPoints : String -> Block -> Expect.Expectation
+expectPolygonWithPoints points block =
+    Block.view 20 ( block, ( 3, 4 ) )
+        |> Query.fromHtml
+        |> Query.find [ tag "polygon" ]
+        |> Query.has [ attribute (Svg.Attributes.points points) ]

--- a/tests/Turnabout/MovesTest.elm
+++ b/tests/Turnabout/MovesTest.elm
@@ -3,7 +3,7 @@ module Turnabout.MovesTest exposing (suite)
 import Test exposing (..)
 import Expect
 import Turnabout.Moves as Moves exposing (..)
-import Turnabout.Direction exposing (Direction(..))
+import Turnabout.Direction exposing (Cardinal(..))
 
 
 suite : Test


### PR DESCRIPTION
Finally got a good algorithm for drawing blocks. Ended up getting some good ideas from:

![25-turtle-geometry-1984-ed](https://user-images.githubusercontent.com/109822/29195880-ddeb490a-7dfe-11e7-9184-d8485bc85ee7.jpg)

Idea is: you can do a recursive right-hand rule for following the edge. If there's a point 45° to the turtle, drop an anchor, move to that square, and face 90° of your current direction, if there's a point ahead, don't drop anything, just move to that square. If there aren't points there, drop an anchor to your top-left, stay in the same place, but _rotate_ -90°. That last insight was the part that took a while.

There's a good way to generalize this solution so there aren't 4 cases the function needs to account for with cardinal directions. I don't know what that good way is yet though, so I just added some tests around it and will maybe get to it later. It can be slow; we can use `Svg.lazy` to draw the shape once.